### PR TITLE
Add install.R to include additional R packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'conda-linux-64.lock'
       - 'environment.yml'
+      - 'install.R'
       - 'Dockerfile'
       # Trigger rebuilds if the build process changes
       - '.github/workflows/build.yaml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'environment.yml'
+      - 'install.R'
       # Trigger rebuilds if the test process changes
       - '.github/workflows/test.yaml'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ RUN echo "Checking for 'conda-linux-64.lock' or 'environment.yml'..." \
         find ${NB_PYTHON_PREFIX}/lib/python*/site-packages/bokeh/server/static -follow -type f -name '*.js' ! -name '*.min.js' -delete \
         ; fi
 
+## Run an install.R script, if it exists.
+RUN if [ -f install.R ]; then R --quiet -f install.R; fi
+
 RUN pip install jupyter-rsession-proxy
 
 WORKDIR ${HOME}

--- a/install.R
+++ b/install.R
@@ -1,0 +1,2 @@
+install.packages("spatialEco")
+install.packages("lidR")


### PR DESCRIPTION
## What has been built?
At the moment I don't believe there is an easy way to add additional R libraries to this environment (I'd love to hear if there is but I missed it!). This PR adds code that allows additional R libraries to be installed via an `install.R` file. It adds two additional libraries, `spatialEco` and `lidR`, as example libraries which previously weren't in the environment.

## How was it done?

* A `RUN` line was added to the Dockerfile which looks for and runs `install.R`
* An `install.R` file was added to the root of the repo

## How can it be tested?

* open the image, open RStudio, and run `library(spatialEco)` or `library(lidR)`